### PR TITLE
Add missing semicolons on javascript statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install --save react-native-pin-view
 
 ```
 
-import PinView from 'react-native-pin-view'
+import PinView from 'react-native-pin-view';
 
 ...
         <PinView
@@ -92,7 +92,7 @@ import PinView from 'react-native-pin-view'
 ```javascript
 import React, { Component } from 'react';
 import { View } from 'react-native';
-import PinView from 'react-native-pin-view'
+import PinView from 'react-native-pin-view';
 
 type Props = {};
 export default class Master extends Component<Props> {
@@ -101,19 +101,19 @@ export default class Master extends Component<Props> {
     this.onComplete = this.onComplete.bind(this);
     this.state = {
         pin: "896745"
-    }
+    };
   }
   onComplete(inputtedPin, clear) {
-    if (val!==this.state.pin){
+    if (val !== this.state.pin) {
       clear();
     } else {
-      console.log("Pin is correct")
+      console.log("Pin is correct");
     }
   }
   onPress(inputtedPin, clear, pressed) {
     console.log("Pressed: "+ pressed);
-    console.log("inputtedPin: "+ inputtedPin)
-    // clear()
+    console.log("inputtedPin: "+ inputtedPin);
+    // clear();
   }
   render() {
     return (


### PR DESCRIPTION
I've seen some line of example javascript code has semicolons and some line hasn't, so I thought it's would be good to make all statements has a semicolon.