### PR TITLE
Add buttonActiveOpacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ import PinView from 'react-native-pin-view'
 | ------------------------ | --------- | ------- | ----------------------------------------------------------------------------------------------------- | -------- |
 | **`buttonTextColor`**    | `string`  | `#333`  | Color of the texts on the number keyboard.                                                            | No       |
 | **`buttonBgColor`**      | `string`  | `#FFF`  | Background of the buttons on the number keyboard                                                      | No       |
+| **`buttonActiveOpacity`**           | `number` | 0.9   | This prop is for styling keyboard button opacity on press. | No       |
 | **`inputBgColor`**       | `string`  | `#333`  | Input color before entering the pin                                                                   | No       |
 | **`inputBgOpacity`**     | `number`  | `0.1`   | Input opacity before entering the pin                                                                 | No       |
 | **`inputActiveBgColor`** | `string`  | `#333`  | The input color that is active when entering the pin.                                                 | No       |
@@ -82,7 +83,7 @@ import PinView from 'react-native-pin-view'
 | **`inputViewStyle`**           | `object` | `{borderRadius:6}`   | This props for styling input view item. | No       |
 | **`keyboardViewStyle`**           | `object` | `{borderRadius:6}`   | This props for styling keyboard view item. | No       |
 | **`keyboardViewTextStyle`**           | `object` | `{fontWeight:'normal'}`   | This props for styling keyboard view text. | No       |
-| **`keyboardContainerStyle`**           | `object` | `{marginTop:10}`   | This props for styling keyboard container view text. | No       |
+| **`keyboardContainerStyle`**           | `object` | `{marginTop:10}`   | This props for styling keyboard container view. | No       |
 | **`onPress`**         | `func`    | `undefined`    | When the user presses the keypad, the inputted **`value`** (PIN code) will return. Also **`clear()`** is returned and the value of the **pressed** key. So if you want to remove user input after **onPress** call **`clear()`** func in onPress, or if you want to disable a submit button when the PIN code is not completely filled you can check it's length with `value.length`. Usage: `onPress={(value, clear, pressed) => console.log('value', value, 'clear', clear, 'pressed', pressed)}`| No      |
 | **`buttonDeletePosition`**         | `string`    | `left`    | Delete button position **`left - right`** | No      |
 | **`buttonDeleteStyle`**         | `object`    | `undefined`    | Delete button style | No      |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import PinView from 'react-native-pin-view'
 | ------------------------ | --------- | ------- | ----------------------------------------------------------------------------------------------------- | -------- |
 | **`buttonTextColor`**    | `string`  | `#333`  | Color of the texts on the number keyboard.                                                            | No       |
 | **`buttonBgColor`**      | `string`  | `#FFF`  | Background of the buttons on the number keyboard                                                      | No       |
-| **`buttonActiveOpacity`**           | `number` | 0.9   | This prop is for styling keyboard button opacity on press. | No       |
+| **`buttonActiveOpacity`**           | `number` | `0.9`   | This prop is for styling keyboard button opacity on press. | No       |
 | **`inputBgColor`**       | `string`  | `#333`  | Input color before entering the pin                                                                   | No       |
 | **`inputBgOpacity`**     | `number`  | `0.1`   | Input opacity before entering the pin                                                                 | No       |
 | **`inputActiveBgColor`** | `string`  | `#333`  | The input color that is active when entering the pin.                                                 | No       |
@@ -77,7 +77,7 @@ import PinView from 'react-native-pin-view'
 | **`returnType`**         | `string`  |`string` | _onComplete_ returning value type. It can be `string` or `array`| No      |
 | **`pinLength`**     | `number`  | none         | (Min length: `3` , Max length: `8`) User pin length like `this.state.pin.length` or `5` If you're using hashed pin then set default length all pin or use pin length.  | Yes      |
 | **`disabled`**           | `boolean` | false   | Optionally, you can set this props `true` or `false`. If `true`, the user can not enter the password. | No       |
-| **`delayBeforeOnComplete`**           | `number` | 175   | Optionally, you can set this props for delaying before onComplete event. | No       |
+| **`delayBeforeOnComplete`**           | `number` | `175`   | Optionally, you can set this props for delaying before onComplete event. | No       |
 | **`showInputs`**           | `boolean` | `false`   | If you want to show inputted pin use this props. | No       |
 | **`inputTextStyle`**           | `object` | `{color:'#FFF',fontWeight:'bold'}`   | This props for styling inputted pin text. | No       |
 | **`inputViewStyle`**           | `object` | `{borderRadius:6}`   | This props for styling input view item. | No       |

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ class PinView extends React.Component {
       onPress,
       buttonDeletePosition,
       buttonDeleteStyle,
+      buttonActiveOpacity,
     } = this.props
     return (
       <View pointerEvents={disabled ? "none" : undefined}>
@@ -138,7 +139,7 @@ class PinView extends React.Component {
             onPress={onPress}
             buttonDeletePosition={buttonDeletePosition}
             buttonDeleteStyle={buttonDeleteStyle}
-            activeOpacity={activeOpacity}
+            buttonActiveOpacity={buttonActiveOpacity}
           />
         </View>
       </View>
@@ -165,7 +166,7 @@ PinView.defaultProps = {
   onPress: undefined,
   buttonDeletePosition: "left",
   buttonDeleteStyle: StyleSheet.create({}),
-  activeOpacity: 0.9,
+  buttonActiveOpacity: 0.9,
 }
 PinView.propTypes = {
   disabled: PropTypes.bool,
@@ -188,7 +189,7 @@ PinView.propTypes = {
   onPress: PropTypes.func,
   buttonDeletePosition: PropTypes.string,
   buttonDeleteStyle: ViewPropTypes.style,
-  activeOpacity: PropTypes.number,
+  buttonActiveOpacity: PropTypes.number,
 }
 
 export default PinView

--- a/libs/parts/KeyboardView.js
+++ b/libs/parts/KeyboardView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Animated, FlatList, Text, TouchableOpacity, I18nManager} from "react-native";
 
-const KeyboardView = ({ keyboardOnPress, keyboardViewStyle, keyboardViewTextStyle, pinLength, onComplete, bgColor, returnType, textColor, animatedDeleteButton, deleteText, animatedDeleteButtonOnPress, styles, onPress, buttonDeletePosition, buttonDeleteStyle, activeOpacity }) => {
+const KeyboardView = ({ keyboardOnPress, keyboardViewStyle, keyboardViewTextStyle, pinLength, onComplete, bgColor, returnType, textColor, animatedDeleteButton, deleteText, animatedDeleteButtonOnPress, styles, onPress, buttonDeletePosition, buttonDeleteStyle, buttonActiveOpacity }) => {
   let data = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
   const leftButtonDeletePositions = [deleteText, "0", 'empty'];
   const rightButtonDeletePositions = ['empty', "0", deleteText];
@@ -50,7 +50,7 @@ const KeyboardView = ({ keyboardOnPress, keyboardViewStyle, keyboardViewTextStyl
     return (
       <TouchableOpacity
         key={"key-item-" + index}
-        activeOpacity={activeOpacity}
+        activeOpacity={buttonActiveOpacity}
         onPress={onPressKeyboard}
         disabled={onPressInactive}>
         <Animated.View style={[style, {


### PR DESCRIPTION
When having e.g. very dark keyboard buttons, a fixed opacity of 0.9 makes it hard to see the feedback when pressing the buttons. This PR adds a customisable activeOpacity on the buttons. 