### PR TITLE
[styles]: provided styles overriding fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ const ViewButton = ({
       <View
         style={[
           PinViewStyle.buttonView,
-          customViewStyle,
           { width: buttonSize, height: buttonSize, borderRadius: buttonSize / 2 },
+          customViewStyle,
         ]}>
         {customComponent !== undefined ? (
           customComponent
@@ -54,8 +54,8 @@ const ViewInput = ({
       <View
         style={[
           PinViewStyle.inputView,
-          customStyle,
           { width: size, height: size, borderRadius: size / 2, alignItems: "center", justifyContent: "center" },
+          customStyle,
           text !== undefined ? inputFilledStyle : inputEmptyStyle,
         ]}>
         <Text style={[PinViewStyle.inputText, inputTextStyle]}>{text}</Text>
@@ -66,8 +66,8 @@ const ViewInput = ({
       <View
         style={[
           PinViewStyle.inputView,
-          customStyle,
           { width: size, height: size, borderRadius: size / 2 },
+          customStyle,
           text !== undefined ? inputFilledStyle : inputEmptyStyle,
         ]}
       />
@@ -110,6 +110,8 @@ const PinView = React.forwardRef(
       customRightButtonViewStyle,
       customLeftButtonDisabled,
       customRightButtonDisabled,
+      customLeftButtonSize = 60,
+      customRightButtonSize = 60,
     },
     ref
   ) => {
@@ -270,6 +272,7 @@ const PinView = React.forwardRef(
             text={buttonTextByKey.zero}
             customTextStyle={buttonTextStyle}
             customViewStyle={buttonViewStyle}
+            buttonSize={customLeftButtonSize}
           />
           {customRightButton !== undefined ? (
             <ViewButton
@@ -280,6 +283,7 @@ const PinView = React.forwardRef(
               onButtonPress={() => onButtonPress("custom_right")}
               customViewStyle={customRightButtonViewStyle}
               customComponent={customRightButton}
+              buttonSize={customRightButtonSize}
             />
           ) : (
             <ViewHolder />


### PR DESCRIPTION
Let custom styles override over default calculated. For today I need to pass custom button height and width, but it`s equal to 60 by default. So you need to provide extra props to your lib. As I also told, I think it would be better for the Button component to change not View style but TouchableOpacitys.
Please, add extra props asap.